### PR TITLE
chore: attempt to write karma setup for it.each

### DIFF
--- a/karma.setup.js
+++ b/karma.setup.js
@@ -4,3 +4,6 @@ import expect from "expect";
 // Missing jest functions should be added here, if required.
 window.jest = jest;
 window.expect = expect;
+
+window.it.each = (table) => (name, fn) =>
+  table.forEach((args) => window.it(name, () => fn(...args)));

--- a/src/isOdd.spec.ts
+++ b/src/isOdd.spec.ts
@@ -1,13 +1,11 @@
 import { isOdd } from "./isOdd";
 
 describe(isOdd.name, () => {
-  ([
+  it.each([
     [true, 1],
     [false, 2],
-  ] as [boolean, number][]).forEach(([expected, number]) => {
-    it(`returns ${expected} for ${number}`, () => {
-      expect(isOdd(number)).toBe(expected);
-    });
+  ])(`returns %p for %i`, (expected, number) => {
+    expect(isOdd(number)).toBe(expected);
   });
 
   [null, true, "str", [], {}].forEach((notNumber) => {


### PR DESCRIPTION
This is an attempt to write it.each pollyfill in `karma.setup.js`

<details>
<summary>Test failure</summary>

```console
Chrome Headless 89.0.4389.90 (Mac OS 10.15.7) ERROR
  An error was thrown in afterAll
  TypeError: it.each is not a function
      at Suite.<anonymous> (src/isOdd.spec.ts:4:6 <- src/isOdd.spec.js:5:8)
      at <Jasmine>
      at Object.global.wrappers./Users/trivikr/workspace/ts-jest-karma-tests/src/isOdd.spec.ts../isOdd (src/isOdd.spec.ts:3:1 <- src/isOdd.spec.js:4:1)
      at require (node_modules/karma-typescript/dist/client/commonjs.js:17:25)
      at node_modules/karma-typescript/dist/client/commonjs.js:38:9
      at Array.forEach (<anonymous>)
      at node_modules/karma-typescript/dist/client/commonjs.js:37:40
      at node_modules/karma-typescript/dist/client/commonjs.js:40:3
Chrome Headless 89.0.4389.90 (Mac OS 10.15.7): Executed 0 of 0 ERROR (0 secs / 0 secs)
Chrome Headless 89.0.4389.90 (Mac OS 10.15.7) ERROR
  An error was thrown in afterAll
  TypeError: it.each is not a function
      at Suite.<anonymous> (src/isOdd.spec.ts:4:6 <- src/isOdd.spec.js:5:8)
      at <Jasmine>
      at Object.global.wrappers./Users/trivikr/workspace/ts-jest-karma-tests/src/isOdd.spec.ts../isOdd (src/isOdd.spec.ts:3:1 <- src/isOdd.spec.js:4:1)
      at require (node_modules/karma-typescript/dist/client/commonjs.js:17:25)
      at node_modules/karma-typescript/dist/client/commonjs.js:38:9
      at Array.forEach (<anonymous>)
      at node_modules/karma-typescript/dist/client/commonjs.js:37:40
Chrome Headless 89.0.4389.90 (Mac OS 10.15.7): Executed 0 of 0 ERROR (0.01 secs / 0 secs)
```

</details>
