### PR TITLE
chore: remove karma.setup.js

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,8 +3,7 @@ module.exports = function (config) {
     frameworks: ["jasmine", "karma-typescript"],
     files: ["src/**/*.ts"],
     preprocessors: {
-      "./karma.setup.js": ["karma-typescript"],
-      "src/**/*.ts": ["karma-typescript"],
+      "**/*.ts": ["karma-typescript"],
     },
     reporters: ["progress", "karma-typescript"],
     browsers: ["ChromeHeadlessNoSandbox"],

--- a/karma.setup.js
+++ b/karma.setup.js
@@ -1,6 +1,0 @@
-import jest from "jest-mock";
-import expect from "expect";
-
-// Missing jest functions should be added here, if required.
-window.jest = jest;
-window.expect = expect;

--- a/package.json
+++ b/package.json
@@ -30,9 +30,7 @@
   "homepage": "https://github.com/trivikr/ts-jest-karma-tests#readme",
   "devDependencies": {
     "@types/jest": "^26.0.21",
-    "expect": "^26.6.2",
     "jest": "^26.6.3",
-    "jest-mock": "^26.6.2",
     "karma": "^6.2.0",
     "karma-chrome-launcher": "^3.1.0",
     "karma-jasmine": "^4.0.1",


### PR DESCRIPTION
Remove `karma.setup.js` as we're not overwriting jest functions.
It can be re-added if any functions need to be overwritten by following [these instructions](https://github.com/tom-sherman/blog/blob/master/posts/02-running-jest-tests-in-a-browser.md#step-4-add-a-karma-setupjs)