### PR TITLE
chore: add isEven which calls isOdd

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,9 +1,9 @@
 module.exports = function (config) {
   config.set({
     frameworks: ["jasmine", "karma-typescript"],
-    files: ["src/**/*.ts"],
+    files: ["karma.setup.js", "src/**/*.ts"],
     preprocessors: {
-      "./karma.setup.js": ["karma-typescript"],
+      "karma.setup.js": ["karma-typescript"],
       "src/**/*.ts": ["karma-typescript"],
     },
     reporters: ["progress", "karma-typescript"],
@@ -15,5 +15,14 @@ module.exports = function (config) {
       },
     },
     singleRun: true,
+    karmaTypescriptConfig: {
+      compilerOptions: {
+        allowJs: true,
+        esModuleInterop: true,
+      },
+      bundlerOptions: {
+        addNodeGlobals: false,
+      },
+    },
   });
 };

--- a/karma.setup.js
+++ b/karma.setup.js
@@ -1,6 +1,6 @@
 import jest from "jest-mock";
-import expect from "expect";
+// import expect from "expect";
 
 // Missing jest functions should be added here, if required.
 window.jest = jest;
-window.expect = expect;
+// window.expect = expect;

--- a/src/isEven.spec.ts
+++ b/src/isEven.spec.ts
@@ -1,0 +1,22 @@
+import { isEven } from "./isEven";
+import { isOdd } from "./isOdd";
+
+jest.mock("./isOdd");
+
+describe(isEven.name, () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  ([
+    [false, 1],
+    [true, 2],
+  ] as [boolean, number][]).forEach(([expected, number]) => {
+    it(`returns ${expected} for ${number}`, () => {
+      (isOdd as jest.Mock).mockReturnValueOnce(!expected);
+      expect(isEven(number)).toBe(expected);
+      expect(isOdd).toHaveBeenCalledTimes(1);
+      expect(isOdd).toHaveBeenCalledWith(number);
+    });
+  });
+});

--- a/src/isEven.ts
+++ b/src/isEven.ts
@@ -1,0 +1,5 @@
+import { isOdd } from "./isOdd";
+
+const isEven = (value: number) => !isOdd(value);
+
+export { isEven };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     // "lib": [],                                   /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                             /* Allow javascript files to be compiled. */
+    "allowJs": true /* Allow javascript files to be compiled. */,
     // "checkJs": true,                             /* Report errors in .js files. */
     // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
     // "declaration": true,                         /* Generates corresponding '.d.ts' file. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     // "lib": [],                                   /* Specify library files to be included in the compilation. */
-    "allowJs": true /* Allow javascript files to be compiled. */,
+    // "allowJs": true,                             /* Allow javascript files to be compiled. */
     // "checkJs": true,                             /* Report errors in .js files. */
     // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
     // "declaration": true,                         /* Generates corresponding '.d.ts' file. */


### PR DESCRIPTION
Testing isEven which calls isOdd. The `test:browser` fails with `TypeError: jest.mock is not a function`

<details>
<summary>test:browser output</summary>

```console
Chrome Headless 89.0.4389.90 (Mac OS 10.15.7) ERROR
  An error was thrown in afterAll
  Uncaught TypeError: jest.mock is not a function
  TypeError: jest.mock is not a function
      at Object.global.wrappers./Users/trivikr/workspace/ts-jest-karma-tests/src/isEven.spec.ts../isEven (src/isEven.spec.ts:4:6 <- src/isEven.spec.js:5:6)
      at require (node_modules/karma-typescript/dist/client/commonjs.js:17:25)
      at node_modules/karma-typescript/dist/client/commonjs.js:38:9
      at Array.forEach (<anonymous>)
      at node_modules/karma-typescript/dist/client/commonjs.js:37:40
      at node_modules/karma-typescript/dist/client/commonjs.js:40:3
Chrome Headless 89.0.4389.90 (Mac OS 10.15.7): Executed 0 of 0 ERROR (0 secs / 0 secs)
Chrome Headless 89.0.4389.90 (Mac OS 10.15.7) ERROR
  An error was thrown in afterAll
  Uncaught TypeError: jest.mock is not a function
  TypeError: jest.mock is not a function
      at Object.global.wrappers./Users/trivikr/workspace/ts-jest-karma-tests/src/isEven.spec.ts../isEven (src/isEven.spec.ts:4:6 <- src/isEven.spec.js:5:6)
      at require (node_modules/karma-typescript/dist/client/commonjs.js:17:25)
      at node_modules/karma-typescript/dist/client/commonjs.js:38:9
      at Array.forEach (<anonymous>)
      at node_modules/karma-typescript/dist/client/commonjs.js:37:40
Chrome Headless 89.0.4389.90 (Mac OS 10.15.7): Executed 0 of 0 ERROR (0.01 secs / 0 secs)
```

</details>